### PR TITLE
Fixes the splitsentence example by passing a ptr to the Read method

### DIFF
--- a/example/splitsentence/splitsentence.go
+++ b/example/splitsentence/splitsentence.go
@@ -69,7 +69,7 @@ func main() {
 		var sentence string
 		// We have to read Raw here, since the spout is not json encoding the tuple contents
 		meta := &messages.BoltMsgMeta{}
-		err := boltConn.ReadBoltMsg(meta, sentence)
+		err := boltConn.ReadBoltMsg(meta, &sentence)
 		if err != nil {
 			panic(err)
 		}


### PR DESCRIPTION
Fixes Issue #3
