### PR TITLE
Adds json marshaling of the need_task_ids field to json_object

### DIFF
--- a/messages/messages.go
+++ b/messages/messages.go
@@ -197,8 +197,9 @@ type ShellMsg struct {
 }
 
 func (this *ShellMsg) MarshalJSON() ([]byte, error) {
+	command := this.ShellMsgJson.ShellMsgMeta.Command
 	result := map[string]interface{}{
-		"command": this.ShellMsgJson.ShellMsgMeta.Command,
+		"command": command,
 	}
 	if id := this.ShellMsgJson.ShellMsgMeta.GetId(); len(id) > 0 {
 		result["id"] = id
@@ -217,6 +218,9 @@ func (this *ShellMsg) MarshalJSON() ([]byte, error) {
 	}
 	if contents := this.ShellMsgJson.Contents; len(contents) > 0 {
 		result["tuple"] = contents
+	}
+	if command == "emit" && !this.ShellMsgJson.ShellMsgMeta.GetNeedTaskIds() {
+		result["need_task_ids"] = false
 	}
 	return json.Marshal(result)
 }

--- a/messages/messages_test.go
+++ b/messages/messages_test.go
@@ -23,14 +23,14 @@ func TestMarshalShellMsg(t *testing.T) {
 	msg := getMessage()
 
 	// Verifies that excluded fields (stream) aren't marshaled
-	expected := []byte(`{"anchors":["anchor1, anchor2"],"command":"foo","id":"id","msg":"{\"hello\":\"there\"}","task":123}`)
+	expected := []byte(`{"anchors":["anchor1, anchor2"],"command":"emit","id":"id","msg":"{\"hello\":\"there\"}","need_task_ids":false,"task":123}`)
 	verifyJsonOutput(t, msg, expected)
 
 	// Verfies that complex tuples are json marshaled just once.
 	stream := "some_stream"
 	msg.ShellMsgJson.ShellMsgMeta.Stream = &stream
 	msg.ShellMsgJson.Contents = getTestTuple()
-	expected = []byte(`{"anchors":["anchor1, anchor2"],"command":"foo","id":"id","msg":"{\"hello\":\"there\"}","stream":"some_stream","task":123,"tuple":[{"Field1":"Lorem ipsum dolor sit amet, consectetur adipisicing elit","Field2":"sed do eiusmod tempor incididunt ut labore","Field3":12345},{"Field1":"sed quia consequuntur magni dolores eos qui","Field2":"ratione voluptatem sequi nesciunt. Neque porro quisquam","Field3":654321}]}`)
+	expected = []byte(`{"anchors":["anchor1, anchor2"],"command":"emit","id":"id","msg":"{\"hello\":\"there\"}","need_task_ids":false,"stream":"some_stream","task":123,"tuple":[{"Field1":"Lorem ipsum dolor sit amet, consectetur adipisicing elit","Field2":"sed do eiusmod tempor incididunt ut labore","Field3":12345},{"Field1":"sed quia consequuntur magni dolores eos qui","Field2":"ratione voluptatem sequi nesciunt. Neque porro quisquam","Field3":654321}]}`)
 	verifyJsonOutput(t, msg, expected)
 }
 
@@ -65,7 +65,7 @@ func getMessage() *ShellMsg {
 	return &ShellMsg{
 		ShellMsgJson: &ShellMsgJson{
 			ShellMsgMeta: &ShellMsgMeta{
-				Command:     "foo",
+				Command:     "emit",
 				Anchors:     []string{"anchor1, anchor2"},
 				Id:          &id,
 				Stream:      nil,


### PR DESCRIPTION
I thought that I broke this with e561305e0224e073b3521ebd32332bae39bb222f, but it doesn't look to me like ShellMsg ever included need_task_ids in the message sent, which explains why I was still seeing taskIds returned from spouts and bolts.

Either way, this adds it to the message sent back to storm (for emits). 
